### PR TITLE
Run bun install when `mix setup` is run

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,7 @@ defmodule Kobrakai.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "assets.setup", "assets.build"],
-      "assets.setup": ["bun.install --if-missing"],
+      "assets.setup": ["bun.install --if-missing", "bun install"],
       "assets.build": ["bun default", "bun css", "bun storybook"],
       # Opt out of --minify-identifiers due to
       # https://github.com/oven-sh/bun/issues/7710


### PR DESCRIPTION
Without this on a fresh repo when you run `mix setup` you get errors like:
```
26 | import "@appnest/masonry-layout";
            ^
error: Could not resolve: "@appnest/masonry-layout". Maybe you need to "bun install"?
    at /Users/jason/dev/forks/kobrakai_elixir/assets/js/app.js:26:8
** (Mix) `mix bun default` exited with 1
```